### PR TITLE
Refactor core components into layered layout

### DIFF
--- a/agent_manager/__init__.py
+++ b/agent_manager/__init__.py
@@ -1,0 +1,3 @@
+from .infrastructure.api import app
+
+__all__ = ['app']

--- a/agent_manager/application/__init__.py
+++ b/agent_manager/application/__init__.py
@@ -1,0 +1,13 @@
+from .agent_ops import (
+    configure,
+    generate_agent_information,
+    store_information,
+    find_pair_information,
+)
+
+__all__ = [
+    'configure',
+    'generate_agent_information',
+    'store_information',
+    'find_pair_information',
+]

--- a/agent_manager/application/agent_ops.py
+++ b/agent_manager/application/agent_ops.py
@@ -1,0 +1,57 @@
+from typing import List, Tuple
+import json
+import os
+from . import models
+
+PAIR_FILE = 'AR_Agent.json'
+
+current_host = 0
+port_counter = 8888
+ws_counter = 50051
+hosts: List[str] = []
+accounts: List[str] = []
+passwords: List[str] = []
+
+def configure(host_list: List[str], account_list: List[str], password_list: List[str]):
+    global hosts, accounts, passwords
+    hosts = host_list
+    accounts = account_list
+    passwords = password_list
+
+
+def generate_agent_information() -> Tuple[int, int, int]:
+    global current_host, port_counter, ws_counter, hosts
+    host_index = current_host
+    current_host = (current_host + 1) % len(hosts) if hosts else 0
+    port_counter += 1
+    ws_counter += 1
+    return host_index, port_counter - 1, ws_counter - 1
+
+
+def store_information(info: models.AgentInfo) -> None:
+    if os.path.exists(PAIR_FILE):
+        with open(PAIR_FILE, 'r') as fp:
+            data = json.load(fp)
+    else:
+        data = []
+    # remove old
+    data = [d for d in data if d.get('AR') != info.AR]
+    data.append({
+        'AR': info.AR,
+        'Agent': info.agent,
+        'AgentPort': info.agentPort,
+        'AgentWebsocketPort': info.websocketPort
+    })
+    with open(PAIR_FILE, 'w') as fp:
+        json.dump(data, fp)
+
+
+def find_pair_information(ar: str) -> models.AgentInfo | None:
+    if not os.path.exists(PAIR_FILE):
+        return None
+    with open(PAIR_FILE, 'r') as fp:
+        data = json.load(fp)
+    for d in data:
+        if d['AR'] == ar:
+            return models.AgentInfo(d['AR'], d['Agent'], d['AgentPort'], d['AgentWebsocketPort'])
+    return None

--- a/agent_manager/domain/__init__.py
+++ b/agent_manager/domain/__init__.py
@@ -1,0 +1,3 @@
+from .models import AgentInfo
+
+__all__ = ['AgentInfo']

--- a/agent_manager/domain/models.py
+++ b/agent_manager/domain/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+@dataclass
+class AgentInfo:
+    AR: str
+    agent: str
+    agentPort: int
+    websocketPort: int

--- a/agent_manager/infrastructure/__init__.py
+++ b/agent_manager/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from .api import app
+
+__all__ = ['app']

--- a/agent_manager/infrastructure/api.py
+++ b/agent_manager/infrastructure/api.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, Request
+from ..application import agent_ops
+from ..domain import models
+
+app = FastAPI()
+
+@app.post('/subscribe')
+async def subscribe(request: Request):
+    ar_ip = request.client.host
+    host_index, port, ws_port = agent_ops.generate_agent_information()
+    agent_ip = agent_ops.hosts[host_index] if agent_ops.hosts else '0.0.0.0'
+    info = models.AgentInfo(ar_ip, agent_ip, port, ws_port)
+    agent_ops.store_information(info)
+    return {"IP": agent_ip, "Port": port, "WebsocketPort": ws_port}
+
+@app.get('/agent')
+async def get_agent(request: Request):
+    ar_ip = request.client.host
+    info = agent_ops.find_pair_information(ar_ip)
+    if not info:
+        return {"IP": "", "Port": 0, "WebsocketPort": 0}
+    return {"IP": info.agent, "Port": info.agentPort, "WebsocketPort": info.websocketPort}

--- a/controller/application/__init__.py
+++ b/controller/application/__init__.py
@@ -1,0 +1,4 @@
+from . import service_ops
+from .optimizer import optimize
+
+__all__ = ['service_ops', 'optimize']

--- a/controller/application/optimizer.py
+++ b/controller/application/optimizer.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# reuse existing optimizer implementation
+sys.path.append(str(Path(__file__).resolve().parents[2] / 'Controller'))
+from optimizer import optimize
+__all__ = ['optimize']

--- a/controller/application/service_ops.py
+++ b/controller/application/service_ops.py
@@ -1,0 +1,32 @@
+from typing import List
+from . import optimizer
+from ..domain.models import ServiceInstance, ServiceSpec
+
+# wrapper around existing optimizer function
+
+def compute_frequency(serviceType: str, agentCounter: int, services: List[ServiceInstance]) -> List[ServiceInstance]:
+    service_dicts = [s.to_dict() for s in services]
+    status, relation_list = optimizer.optimize(serviceType, agentCounter, service_dicts)
+    if status == 'fail':
+        return []
+    return [ServiceInstance.from_dict(d) for d in relation_list]
+
+
+def deploy_service(serviceType: str, node: str, host_port: int, host_ip: str, spec: ServiceSpec) -> ServiceInstance:
+    return ServiceInstance(
+        podIP=f'{host_ip}',
+        hostPort=host_port,
+        serviceType=serviceType,
+        currentConnection=0,
+        nodeName=node,
+        hostIP=host_ip,
+        frequencyLimit=spec.frequencyLimit,
+        currentFrequency=spec.frequencyLimit[0],
+        workloadLimit=spec.workAbility.get(node, 0)
+    )
+
+
+def adjust_frequency(serviceType: str, services: List[ServiceInstance]) -> None:
+    for s in services:
+        if s.serviceType == serviceType:
+            s.currentFrequency = min(s.frequencyLimit)

--- a/controller/domain/__init__.py
+++ b/controller/domain/__init__.py
@@ -1,0 +1,8 @@
+from .models import ServiceSpec, ServiceInstance, Subscription, NodeStatus
+
+__all__ = [
+    'ServiceSpec',
+    'ServiceInstance',
+    'Subscription',
+    'NodeStatus',
+]

--- a/controller/domain/models.py
+++ b/controller/domain/models.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+@dataclass
+class ServiceSpec:
+    serviceType: str
+    frequencyLimit: List[int]
+    workAbility: Dict[str, int]
+    gpuMemoryRequest: int
+
+    @staticmethod
+    def from_dict(data: Dict) -> 'ServiceSpec':
+        return ServiceSpec(
+            serviceType=data['serviceType'],
+            frequencyLimit=data.get('frequencyLimit', []),
+            workAbility=data.get('workAbility', {}),
+            gpuMemoryRequest=data.get('gpuMemoryRequest', 0)
+        )
+
+@dataclass
+class ServiceInstance:
+    podIP: str
+    hostPort: int
+    serviceType: str
+    currentConnection: int
+    nodeName: str
+    hostIP: str
+    frequencyLimit: List[int]
+    currentFrequency: int
+    workloadLimit: float
+
+    @staticmethod
+    def from_dict(data: Dict) -> 'ServiceInstance':
+        return ServiceInstance(
+            podIP=data['podIP'],
+            hostPort=data['hostPort'],
+            serviceType=data['serviceType'],
+            currentConnection=data.get('currentConnection', 0),
+            nodeName=data['nodeName'],
+            hostIP=data.get('hostIP', ''),
+            frequencyLimit=data.get('frequencyLimit', []),
+            currentFrequency=data.get('currentFrequency', 0),
+            workloadLimit=data.get('workloadLimit', 0.0)
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            'podIP': self.podIP,
+            'hostPort': self.hostPort,
+            'serviceType': self.serviceType,
+            'currentConnection': self.currentConnection,
+            'nodeName': self.nodeName,
+            'hostIP': self.hostIP,
+            'frequencyLimit': self.frequencyLimit,
+            'currentFrequency': self.currentFrequency,
+            'workloadLimit': self.workloadLimit,
+        }
+
+@dataclass
+class Subscription:
+    agentIP: str
+    agentPort: int
+    podIP: str
+    serviceType: str
+    nodeName: str
+
+    @staticmethod
+    def from_dict(data: Dict) -> 'Subscription':
+        return Subscription(
+            agentIP=data['agentIP'],
+            agentPort=data['agentPort'],
+            podIP=data['podIP'],
+            serviceType=data['serviceType'],
+            nodeName=data.get('nodeName', '')
+        )
+
+    def to_dict(self) -> Dict:
+        return {
+            'agentIP': self.agentIP,
+            'agentPort': self.agentPort,
+            'podIP': self.podIP,
+            'serviceType': self.serviceType,
+            'nodeName': self.nodeName
+        }
+
+@dataclass
+class NodeStatus:
+    nodeName: str
+    status: str
+
+    @staticmethod
+    def from_dict(item: Dict) -> 'NodeStatus':
+        # expecting {'name': name, 'status': status}
+        return NodeStatus(nodeName=item['name'], status=item['status'])
+

--- a/controller/infrastructure/__init__.py
+++ b/controller/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from .api import app
+
+__all__ = ['app']

--- a/controller/infrastructure/api.py
+++ b/controller/infrastructure/api.py
@@ -1,0 +1,64 @@
+import json
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+from ..domain.models import ServiceInstance, ServiceSpec, Subscription
+from ..application import service_ops
+
+SERVICE_FILE = './Controller/information/service.json'
+SERVICESPEC_FILE = './Controller/information/serviceSpec.json'
+SUBSCRIPTION_FILE = './Controller/information/subscription.json'
+
+app = FastAPI()
+
+class SubscriptionRequest(BaseModel):
+    ip: str
+    port: int
+    serviceType: str
+
+@app.post('/subscribe')
+async def subscribe(request: Request, subscription: SubscriptionRequest):
+    try:
+        with open(SERVICE_FILE, 'r') as fp:
+            service_data = [ServiceInstance.from_dict(x) for x in json.load(fp)]
+    except FileNotFoundError:
+        service_data = []
+
+    try:
+        with open(SERVICESPEC_FILE, 'r') as fp:
+            spec_data = [ServiceSpec.from_dict(x) for x in json.load(fp)]
+    except FileNotFoundError:
+        raise HTTPException(status_code=500, detail='ServiceSpec file not found')
+
+    relation_list = service_ops.compute_frequency(subscription.serviceType, 1, service_data)
+    if not relation_list:
+        raise HTTPException(status_code=500, detail='Unable to compute frequency')
+
+    # simply choose first relation instance
+    target = relation_list[0]
+    sub = Subscription(subscription.ip, subscription.port, target.podIP, subscription.serviceType, target.nodeName)
+    try:
+        with open(SUBSCRIPTION_FILE, 'r') as fp:
+            subs = [Subscription.from_dict(x) for x in json.load(fp)]
+    except FileNotFoundError:
+        subs = []
+    subs.append(sub)
+    with open(SUBSCRIPTION_FILE, 'w') as fp:
+        json.dump([s.to_dict() for s in subs], fp, indent=4)
+    with open(SERVICE_FILE, 'w') as fp:
+        json.dump([s.to_dict() for s in relation_list], fp, indent=4)
+    return {"IP": target.hostIP, "Port": target.hostPort, "Frequency": target.currentFrequency}
+
+@app.post('/unsubscribe')
+async def unsubscribe(request: Request):
+    data = await request.json()
+    agent_ip = request.client.host
+    agent_port = data.get('port')
+    try:
+        with open(SUBSCRIPTION_FILE, 'r') as fp:
+            subs = [Subscription.from_dict(x) for x in json.load(fp)]
+    except FileNotFoundError:
+        subs = []
+    subs = [s for s in subs if not (s.agentIP == agent_ip and s.agentPort == agent_port)]
+    with open(SUBSCRIPTION_FILE, 'w') as fp:
+        json.dump([s.to_dict() for s in subs], fp, indent=4)
+    return {'message': 'unsubscribe finish'}

--- a/monitor/__init__.py
+++ b/monitor/__init__.py
@@ -1,0 +1,3 @@
+from .infrastructure.main import app
+
+__all__ = ['app']

--- a/monitor/application/__init__.py
+++ b/monitor/application/__init__.py
@@ -1,0 +1,3 @@
+from .monitor_ops import query_prometheus, parse_node_ready
+
+__all__ = ['query_prometheus', 'parse_node_ready']

--- a/monitor/application/monitor_ops.py
+++ b/monitor/application/monitor_ops.py
@@ -1,0 +1,21 @@
+import requests
+import asyncio
+from ..domain import models
+
+PROMETHEUS_URL = 'http://prometheus-stack-kube-prom-prometheus.prometheus.svc.cluster.local:9090/api/v1/query'
+
+async def query_prometheus(query: str):
+    resp = requests.get(PROMETHEUS_URL, params={'query': query})
+    if resp.status_code == 200:
+        return resp.json()
+    return None
+
+async def parse_node_ready(data) -> list[models.NodeStatus]:
+    nodes = []
+    if not data:
+        return nodes
+    for result in data.get('data', {}).get('result', []):
+        node = result['metric']['node']
+        status = 'Ready' if result['value'][1] == '1' else 'NotReady'
+        nodes.append(models.NodeStatus(node, status))
+    return nodes

--- a/monitor/domain/__init__.py
+++ b/monitor/domain/__init__.py
@@ -1,0 +1,3 @@
+from .models import NodeStatus
+
+__all__ = ['NodeStatus']

--- a/monitor/domain/models.py
+++ b/monitor/domain/models.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class NodeStatus:
+    node: str
+    status: str

--- a/monitor/infrastructure/__init__.py
+++ b/monitor/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ['app']

--- a/monitor/infrastructure/main.py
+++ b/monitor/infrastructure/main.py
@@ -1,0 +1,14 @@
+import asyncio
+from fastapi import FastAPI
+from ..application import monitor_ops
+
+app = FastAPI()
+
+@app.get('/nodes')
+async def nodes_ready():
+    data = await monitor_ops.query_prometheus('kube_node_status_condition{condition="Ready",status="true"}')
+    return [ns.__dict__ for ns in await monitor_ops.parse_node_ready(data)]
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add dataclasses for controller domain objects
- expose application functions for service frequency and deployment logic
- keep FastAPI endpoints under infrastructure modules
- split AgentManager and Monitor into application/infrastructure packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877abda582c8331a50ed1970ecd22bd